### PR TITLE
Exclude admin users from Discord leaderboard command

### DIFF
--- a/discord_files/cogs/economy.py
+++ b/discord_files/cogs/economy.py
@@ -1021,7 +1021,7 @@ class EconomyCog(commands.Cog):
     async def leaderboard(self, interaction: discord.Interaction):
         """Show the top 10 users by pitchfork balance"""
         with self.app.app_context():
-            top_users = self.User.query.order_by(self.User.balance.desc()).limit(10).all()
+            top_users = self.User.query.filter(self.User.is_admin == False).order_by(self.User.balance.desc()).limit(10).all()
             
             embed = discord.Embed(
                 title="🏆 Pitchfork Leaderboard",


### PR DESCRIPTION
- Modified /leaderboard command to filter out users with is_admin=True
- Only non-admin users will now appear in the top 10 leaderboard rankings
- Gives regular community members better visibility in rankings